### PR TITLE
Ensure that Contactperson is below item information

### DIFF
--- a/seantis/dir/contacts/templates/item.pt
+++ b/seantis/dir/contacts/templates/item.pt
@@ -70,7 +70,7 @@
             <metal:use use-macro="context/@@seantis-dir-macros/macros/map"></metal:use>
 
         </div>
-
+        <div class="visualClear"><!-- --></div>
         <div id="directoryInfoPage" tal:condition="view/contacts">
             <h2 i18n:translate="Contact persons"></h2>
             <div class="directoryDetailsBlock" tal:repeat="contact view/contacts">


### PR DESCRIPTION
We had the Bug that the Contactperson is floated and on the same height as the Item Information. With this Patch we add a visual-clear to prevent this.
